### PR TITLE
BUGFIX: Copy custom.cloudWatchLogsTags object

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -63,7 +63,7 @@ class ServerlessCloudWatchLogsTagPlugin {
       return new Promise(async (resolve, _) => {
         const params = {
           logGroupName: resource.PhysicalResourceId,
-          tags: custom.cloudWatchLogsTags,
+          tags: { ...custom.cloudWatchLogsTags },
         } as TagLogGroupsParams;
         if (custom.addLambdaTagsOnLogGroups && custom.customTagsFromLambda) {
           await this.handleTagsFromLambda(resource, custom.customTagsFromLambda, params);


### PR DESCRIPTION
This pull request resolves a bug in the current implementation where `custom.cloudWatchLogsTags` is passed to `handleTagsFromLambda` which directly modifies the object. This causes the following behaviour:

Lambda A has tags:
- a
- b
- c

Lambda B has tags:
- a

Plugin attemps to handle tags from Lambda A and updates custom.cloudWatchLogs object reference.
`custom.cloudWatchLogsTags` now contains tags a, b, and c.
Plugin attemps to handle tags from Lambda B, and custom.cloudWatchLogs now of tags a, b, and c.
Tag a will be overwrriten with the value specified for Lambda B, but tags b and c will now be attached to the log group for Lambda B.

This PR simply copies the object using the spread operator when assigning it to `params`, so that `this.handleTagsFromLambda` is only modifying a copy of the `custom.cloudWatchLogsTags`