### PR TITLE
chore: mark project as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # serverless-plugin-tag-cloud-watch-logs
 Serverless plugin to tag CloudWatchLogs
 
+## :warning: THIS PROJECT IS DEPRECATED
+
+As an alternative with similar features, we suggest using [serverless-tag-cloud-watch-logs](https://github.com/gfragoso/serverless-tag-cloud-watch-logs).
+
 ## Installation
 Install the plugin via <a href="https://docs.npmjs.com/cli/install">NPM</a>
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pretty-fun-therapy/serverless-plugin-tag-cloud-watch-logs",
   "version": "1.1.1",
-  "description": "Serverless plugin to tag CloudWatchLogs",
+  "description": "DEPRECATED - Serverless plugin to tag CloudWatchLogs",
   "main": "dist/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Once merge, we will follow this procedure:

https://docs.npmjs.com/deprecating-and-undeprecating-packages-or-package-versions